### PR TITLE
v0.1.8: Fix execfile/py2 compatibility.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A command line tool for executing custom python scripts.
 
 * Install clr
 ```
-$ pip install git+https://github.com/color/clr.git@v0.1.7
+$ pip install git+https://github.com/color/clr.git@v0.1.8
 ```
 
 * Create a custom command
@@ -14,7 +14,7 @@ $ pip install git+https://github.com/color/clr.git@v0.1.7
 # color/src/clr_commands/say.py
 class Commands(object):
     descr = "say commands"
-    
+
     def cmd_hello_world(self):
         print "hello world!"
 

--- a/clr/commands.py
+++ b/clr/commands.py
@@ -1,5 +1,5 @@
 from __future__ import print_function
-from past.builtins import execfile
+from importlib import import_module
 from builtins import zip
 from builtins import object
 from past.builtins import intern
@@ -64,10 +64,9 @@ def get_command(which):
     if which == 'system':
         obj = System()
     else:
-        path = path_of_module(clr.config.commands()[which])
-        d    = {}
-        execfile(path, d)
-        obj = d['COMMANDS']
+        mod_path = clr.config.commands()[which]
+        x = import_module(mod_path)
+        obj = x.COMMANDS
 
     # Backfill namespace.
     obj.ns = which

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ except:
 
 
 setup(name = "clr",
-      version = "0.1.7",
+      version = "0.1.8",
       description = "A command line tool for executing custom python scripts.",
       author = "Color Genomics",
       author_email = "dev@getcolor.com",


### PR DESCRIPTION
`execfile` causes the file in question to be eval'd in the current scope, and this causes an error because files in `clr_command` using `print`. This means they are not compatible with `from __future__ import print_function`. Switching to `import_module` fixes this.