### PR TITLE
v0.1.9: Fix `clr help` for commands with no docstring

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A command line tool for executing custom python scripts.
 
 * Install clr
 ```
-$ pip install git+https://github.com/color/clr.git@v0.1.8
+$ pip install git+https://github.com/color/clr.git@v0.1.9
 ```
 
 * Create a custom command

--- a/clr/commands.py
+++ b/clr/commands.py
@@ -51,8 +51,9 @@ def print_help_for_cmd(cmd_, prefix=''):
     w.subsequent_indent += '  '
 
     doc = inspect.getdoc(cmd)
-    for l in doc.split('\n'):
-        print(w.fill(l))
+    if doc is not None:
+        for l in doc.split('\n'):
+            print(w.fill(l))
 
 def get_commands():
     cmds = dict((ns, get_command(ns)) for ns in list(clr.config.commands().keys()))

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ except:
 
 
 setup(name = "clr",
-      version = "0.1.8",
+      version = "0.1.9",
       description = "A command line tool for executing custom python scripts.",
       author = "Color Genomics",
       author_email = "dev@getcolor.com",


### PR DESCRIPTION
Currently if there is at least one command in a namespace that doesn't have a docstring, `clr help namespace` breaks with an exception. 