### PR TITLE
Improve error messages when the command is not found in clr

### DIFF
--- a/clr/commands.py
+++ b/clr/commands.py
@@ -145,7 +145,8 @@ class System(object):
 
         spec, vararg = get_command_spec(command)
 
-        is_default = lambda a_s: a_s[1] is intern('default')
+        def is_default(spec):
+            return a_s[1] == 'default'
         req = [spec_item for spec_item in spec if is_default(spec_item)]
         notreq = [spec_item for spec_item in spec if not is_default(spec_item)]
 

--- a/clr/commands.py
+++ b/clr/commands.py
@@ -11,7 +11,6 @@ import types
 import difflib
 
 import clr.config
-from clr.util import path_of_module
 
 NAMESPACE_KEYS = clr.config.commands().keys() | {'system'}
 # Load lazily.

--- a/clr/commands.py
+++ b/clr/commands.py
@@ -48,8 +48,8 @@ def get_command(namespace_key, command_name):
 
 def _get_close_matches(query, options):
     matches = difflib.get_close_matches(query, options, cutoff=.4)
-    if not matches:
-        matches = sorted(o for o in options if o.startswith(query))
+    if query:
+        matches.extend(sorted(o for o in options if o.startswith(query) and o not in matches))
     return matches
 
 def resolve_command(query):

--- a/clr/commands.py
+++ b/clr/commands.py
@@ -22,7 +22,7 @@ def get_namespaces():
     for key in NAMESPACE_KEYS: get_namespace(key)
     return __namespaces
 
-def load_namespace(key):
+def _load_namespace(key):
     if key == 'system':
         return System()
 
@@ -37,7 +37,7 @@ def get_namespace(namespace_key):
     """Lazily load and return the namespace"""
     global __namespaces
     if namespace_key not in __namespaces:
-        __namespaces[namespace_key] = load_namespace(namespace_key)
+        __namespaces[namespace_key] = _load_namespace(namespace_key)
     return __namespaces[namespace_key]
 
 def list_commands(namespace_key):

--- a/clr/commands.py
+++ b/clr/commands.py
@@ -3,6 +3,8 @@ from importlib import import_module
 from builtins import zip
 from builtins import object
 from past.builtins import intern
+from typing import NamedTuple
+from dataclasses import dataclass
 import inspect
 import sys
 import textwrap
@@ -12,115 +14,14 @@ import difflib
 import clr.config
 from clr.util import path_of_module
 
-# Load lazily
+NAMESPACE_KEYS = clr.config.commands().keys() | {'system'}
+# Load lazily.
 __namespaces = {}
 
-def print_help_for_cmd(cmd_, prefix=''):
-    w = textwrap.TextWrapper(
-        initial_indent=prefix, subsequent_indent=prefix,
-        width=70)
-
-    _, cmd, _, _ = resolve_command(cmd_)
-
-    spec, vararg = get_command_spec(cmd)
-
-    is_default = lambda a_s: a_s[1] is intern('default')
-    req = [spec_item for spec_item in spec if is_default(spec_item)]
-    notreq = [spec_item for spec_item in spec if not is_default(spec_item)]
-
-    args = []
-    if len(req) > 0:
-        args.append(' '.join(['<%s>' % a for a, _ in req]))
-
-    if len(notreq) > 0:
-        def atxt(a, v):
-            if isinstance(v, bool):
-                if v:
-                    return '--no%s' % a
-                else:
-                    return '--%s' % a
-
-            else:
-                return '--%s=%s' % (a, v)
-
-        args.append('[%s]' % ' '.join([atxt(a, v) for a, v in notreq]))
-
-    if vararg is not None:
-        args.append('[%s...]' % vararg)
-
-    print(w.fill('%s %s' % (cmd_, ' '.join(args))))
-
-    w.initial_indent += '  '
-    w.subsequent_indent += '  '
-
-    doc = inspect.getdoc(cmd)
-    if doc is not None:
-        for l in doc.split('\n'):
-            print(w.fill(l))
-
-NAMESPACE_KEYS = clr.config.commands().keys() | {'system'}
-
-def get_namespaces():
-    # Fill namespace cache
-    for namespace in NAMESPACE_KEYS: get_namespace(namespace)
-    return __namespaces
-
-def has_namespace(namespace):
-    return namespace in NAMESPACE_KEYS
-
-def load_namespace(namespace):
-    if namespace == 'system':
-        obj = System()
-    else:
-        mod_path = clr.config.commands()[namespace]
-        x = import_module(mod_path)
-        obj = x.COMMANDS
-
-    # Backfill namespace.
-    obj.ns = obj.namespace = namespace
-    return obj
-
-def get_namespace(namespace):
-    global __namespaces
-    if namespace not in __namespaces:
-        __namespaces[namespace] = load_namespace(namespace)
-    return __namespaces[namespace]
-
-def get_subcommands(namespace):
-    obj = get_namespaces(namespace)
-    return {attr[4:]: getattr(obj, attr) for attr in dir(obj)
-            if attr.startswith('cmd_')}
-
-def get_subcommand(namespace, name):
-    return get_subcommands(namespace).get(name)
-
-def resolve_command(query):
-    """Resolve the string `cmd_' into a (object, method) tuple."""
-    if ':' not in query: query = f'system:{query}'
-
-    namespace_key, cmd_name = query.split(':', 1)
-    method_name = f'cmd_{cmd_name}'
-
-    if not has_namespace(namespace_key):
-        close_matches = difflib.get_close_matches(namespace_key, NAMESPACE_KEYS, cutoff=.4)
-        print(f"Error! Command namespace '{namespace_key}' does not exist.\nClosest matches: {close_matches}\n\nAvaliable namespaces: {sorted(NAMESPACE_KEYS)}", file=sys.stderr)
-        sys.exit(1)
-
-    namespace = get_namespace(namespace_key)
-
-    if not hasattr(namespace, method_name):
-        cmds = sorted(_[4:] for _ in dir(namespace) if _.startswith('cmd_'))
-        close_matches = difflib.get_close_matches(cmd_name, cmds, cutoff=.4)
-        print(f"Error! Command '{cmd_name}'' does not exist in '{namespace_key}'.\nClosest matches: {close_matches}\n\nAvaliable commands: {cmds}", file=sys.stderr)
-        sys.exit(1)
-
-    cmd = getattr(namespace, method_name)
-    return namespace, cmd, namespace_key, cmd_name
-
-def get_command_spec(cmd):
+def get_command_spec(command):
     """Get a command spec from the given (resolved) command, and
     distinguish default args vs. non-default args."""
-    args, vararg, varkwarg, defvals = inspect.getargspec(cmd)
+    args, vararg, varkwarg, defvals = inspect.getargspec(command)
 
     assert varkwarg is None, 'Variable kwargs are not allowed in commands.'
 
@@ -130,7 +31,7 @@ def get_command_spec(cmd):
         defvals = tuple()
 
     # Avoid the self argument.
-    if isinstance(cmd, types.MethodType):
+    if isinstance(command, types.MethodType):
         args = args[1:]
 
     nargs = len(args) - len(defvals)
@@ -138,29 +39,162 @@ def get_command_spec(cmd):
 
     return args, vararg
 
+def get_namespaces():
+    # Fill namespace cache
+    for key in NAMESPACE_KEYS: get_namespace(key)
+    return __namespaces
+
+def has_namespace(key):
+    return key in NAMESPACE_KEYS
+
+def load_namespace(key):
+    if key == 'system':
+        obj = System()
+    else:
+        mod_path = clr.config.commands()[key]
+        try:
+           module = import_module(mod_path)
+           obj = module.COMMANDS
+        except Exception as e:
+            print(f"WARNING: Loading namespace '{key}' failed: {e}")
+            obj = ErrorLoadingNamespace(key, e)
+
+    return obj
+
+def get_namespace(namespace):
+    global __namespaces
+    if namespace not in __namespaces:
+        __namespaces[namespace] = load_namespace(namespace)
+    return __namespaces[namespace]
+
+def list_commands(namespace_key):
+    return sorted(attr[4:] for attr in dir(get_namespace(namespace_key)) if attr.startswith('cmd_'))
+
+def get_command(namespace_key, command_name):
+    return getattr(get_namespace(namespace_key), f'cmd_{command_name}')
+
+def _get_close_matches(query, options):
+    matches = difflib.get_close_matches(query, options, cutoff=.4)
+    if not matches:
+        matches = sorted(o for o in options if o.startswith(query))
+    return matches
+
+def resolve_command(query):
+    """Resolve the string `query' into a (namespace_key, command_name, namespace, method) tuple."""
+
+    if ':' in query:
+        namespace_key, command_name = query.split(':', 1)
+    else:
+        if query in list_commands('system'):
+            # So that `clr help` works as expected.
+            namespace_key = 'system'
+            command_name = query
+        else:
+            # This will still fail, but the error messages will be sensible.
+            namespace_key = query
+            command_name = ''
+
+    if not has_namespace(namespace_key):
+        close_matches = _get_close_matches(namespace_key, NAMESPACE_KEYS)
+        print(f"Error! Command namespace '{namespace_key}' does not exist.\nClosest matches: {close_matches}\n\nAvaliable namespaces: {sorted(NAMESPACE_KEYS)}", file=sys.stderr)
+        sys.exit(1)
+
+    commands = list_commands(namespace_key)
+    if command_name not in commands:
+        close_matches = _get_close_matches(command_name, commands)
+        print(f"Error! Command '{command_name} does not exist in namespace '{namespace_key}'.\nClosest matches: {close_matches}\n\nAvaliable commands: {commands}", file=sys.stderr)
+        sys.exit(1)
+
+    return get_namespace(namespace_key), get_command(namespace_key, command_name), namespace_key, command_name
+
 class System(object):
-    namespace = 'system'
+    """System namespace for the clr tool.
+
+    Commands defined here will be avaliable directly without specifying a
+    namespace. For example `clr help` instead of `clr system:help`. Be careful
+    not to define commands here that have the same name as a defined namespace
+    or it may be obscured."""
+
     descr = 'system commands'
 
-    def cmd_help(self, which=None):
+    def cmd_help(self, query=None, query2=None):
         """
-        provides help for commands, when specified, `which' can be one
+        provides help for commands, when specified, `query' can be one
         either a namespace or a namespace:command tuple.
         """
-        if which is None:
+        if not query:
             print('Available namespaces')
-            for obj in list(get_commands().values()):
-                print(' ', obj.namespace.ljust(20), '-', obj.descr)
-        elif which.find(':') < 0:
-            if which in get_commands():
-                obj = get_commands()[which]
+            for key, namespace in get_namespaces().items():
+                print(' ', key.ljust(20), '-', namespace.descr)
+            return
 
-                print(which, '-', obj.descr)
+        # If they passed just one arg and it is a namespace key, print help for the full namespace.
+        if query in NAMESPACE_KEYS and not query2:
+            namespace = get_namespace(query)
+            descr = namespace.longdescr if hasattr(namespace, 'longdescr') else namespace.descr
+            print(query, '-', descr)
 
-                for k in [k for k in dir(obj) if k.startswith('cmd_')]:
-                    cmd = '%s:%s' % (which, k[4:])
-                    print_help_for_cmd(cmd, prefix='  ')
-            else:
-                print_help_for_cmd('system:%s' % which)
-        else:
-            print_help_for_cmd(which)
+            for command in list_commands(query):
+                self.print_help_for_command(query, command, prefix='  ')
+            return
+
+        if query2: query = f'{query}:{query2}'
+        _, _, namespace_key, command_name = resolve_command(query)
+        self.print_help_for_command(namespace_key, command_name)
+
+    def print_help_for_command(self, namespace_key, command_name, prefix=''):
+        w = textwrap.TextWrapper(
+            initial_indent=prefix, subsequent_indent=prefix,
+            width=70)
+
+        command = get_command(namespace_key, command_name)
+
+        spec, vararg = get_command_spec(command)
+
+        is_default = lambda a_s: a_s[1] is intern('default')
+        req = [spec_item for spec_item in spec if is_default(spec_item)]
+        notreq = [spec_item for spec_item in spec if not is_default(spec_item)]
+
+        args = []
+        if len(req) > 0:
+            args.append(' '.join(['<%s>' % a for a, _ in req]))
+
+        if len(notreq) > 0:
+            def atxt(a, v):
+                if isinstance(v, bool):
+                    if v:
+                        return '--no%s' % a
+                    else:
+                        return '--%s' % a
+
+                else:
+                    return '--%s=%s' % (a, v)
+
+            args.append('[%s]' % ' '.join([atxt(a, v) for a, v in notreq]))
+
+        if vararg is not None:
+            args.append('[%s...]' % vararg)
+
+        print(w.fill('%s %s' % (command_name, ' '.join(args))))
+
+        w.initial_indent += '  '
+        w.subsequent_indent += '  '
+
+        doc = inspect.getdoc(command)
+        if doc is not None:
+            for l in doc.split('\n'):
+                print(w.fill(l))
+
+@dataclass
+class ErrorLoadingNamespace:
+    """Psuedo namespace for when one can't be loaded to show the error message."""
+    key: str
+    error: Exception
+
+    @property
+    def descr(self):
+        return f"ERROR Could not load. See `clr help {self.key}`"
+
+    @property
+    def longdescr(self):
+        return f"Error importing module '{clr.config.commands()[self.key]}' for namespace '{self.key}':\n\n{self.error}"

--- a/clr/commands.py
+++ b/clr/commands.py
@@ -69,13 +69,13 @@ def resolve_command(query):
 
     if namespace_key not in NAMESPACE_KEYS:
         close_matches = _get_close_matches(namespace_key, NAMESPACE_KEYS)
-        print(f"Error! Command namespace '{namespace_key}' does not exist.\nClosest matches: {close_matches}\n\nAvaliable namespaces: {sorted(NAMESPACE_KEYS)}", file=sys.stderr)
+        print(f"Error! Command namespace '{namespace_key}' does not exist.\nClosest matches: {close_matches}\n\nAvailable namespaces: {sorted(NAMESPACE_KEYS)}", file=sys.stderr)
         sys.exit(1)
 
     commands = list_commands(namespace_key)
     if command_name not in commands:
         close_matches = _get_close_matches(command_name, commands)
-        print(f"Error! Command '{command_name} does not exist in namespace '{namespace_key}'.\nClosest matches: {close_matches}\n\nAvaliable commands: {commands}", file=sys.stderr)
+        print(f"Error! Command '{command_name} does not exist in namespace '{namespace_key}'.\nClosest matches: {close_matches}\n\nAvailable commands: {commands}", file=sys.stderr)
         sys.exit(1)
 
     return get_namespace(namespace_key), get_command(namespace_key, command_name), namespace_key, command_name

--- a/clr/commands.py
+++ b/clr/commands.py
@@ -27,23 +27,21 @@ def has_namespace(key):
 
 def load_namespace(key):
     if key == 'system':
-        obj = System()
-    else:
-        mod_path = clr.config.commands()[key]
-        try:
-           module = import_module(mod_path)
-           obj = module.COMMANDS
-        except Exception as e:
-            print(f"WARNING: Loading namespace '{key}' failed: {e}")
-            obj = ErrorLoadingNamespace(key, e)
+        return System()
 
-    return obj
+    module_path = clr.config.commands()[key]
+    try:
+        module = import_module(module_path)
+        return module.COMMANDS
+    except Exception as e:
+        return ErrorLoadingNamespace(key, e)
 
-def get_namespace(namespace):
+def get_namespace(namespace_key):
+    """Lazily load and return the namespace"""
     global __namespaces
-    if namespace not in __namespaces:
-        __namespaces[namespace] = load_namespace(namespace)
-    return __namespaces[namespace]
+    if namespace_key not in __namespaces:
+        __namespaces[namespace_key] = load_namespace(namespace_key)
+    return __namespaces[namespace_key]
 
 def list_commands(namespace_key):
     return sorted(attr[4:] for attr in dir(get_namespace(namespace_key)) if attr.startswith('cmd_'))

--- a/clr/commands.py
+++ b/clr/commands.py
@@ -80,10 +80,10 @@ def resolve_command(query):
 
     return get_namespace(namespace_key), get_command(namespace_key, command_name), namespace_key, command_name
 
-def get_command_spec(command):
+def get_command_spec(cmd):
     """Get a command spec from the given (resolved) command, and
     distinguish default args vs. non-default args."""
-    args, vararg, varkwarg, defvals = inspect.getargspec(command)
+    args, vararg, varkwarg, defvals = inspect.getargspec(cmd)
 
     assert varkwarg is None, 'Variable kwargs are not allowed in commands.'
 
@@ -93,7 +93,7 @@ def get_command_spec(command):
         defvals = tuple()
 
     # Avoid the self argument.
-    if isinstance(command, types.MethodType):
+    if isinstance(cmd, types.MethodType):
         args = args[1:]
 
     nargs = len(args) - len(defvals)

--- a/clr/commands.py
+++ b/clr/commands.py
@@ -17,27 +17,6 @@ NAMESPACE_KEYS = clr.config.commands().keys() | {'system'}
 # failing initialization.
 __namespaces = {}
 
-def get_command_spec(command):
-    """Get a command spec from the given (resolved) command, and
-    distinguish default args vs. non-default args."""
-    args, vararg, varkwarg, defvals = inspect.getargspec(command)
-
-    assert varkwarg is None, 'Variable kwargs are not allowed in commands.'
-
-    if args is None:
-        args = tuple()
-    if defvals is None:
-        defvals = tuple()
-
-    # Avoid the self argument.
-    if isinstance(command, types.MethodType):
-        args = args[1:]
-
-    nargs = len(args) - len(defvals)
-    args = list(zip(args[:nargs], [intern('default')]*nargs)) + list(zip(args[nargs:], defvals))
-
-    return args, vararg
-
 def get_namespaces():
     # Fill namespace cache
     for key in NAMESPACE_KEYS: get_namespace(key)
@@ -105,6 +84,27 @@ def resolve_command(query):
         sys.exit(1)
 
     return get_namespace(namespace_key), get_command(namespace_key, command_name), namespace_key, command_name
+
+def get_command_spec(command):
+    """Get a command spec from the given (resolved) command, and
+    distinguish default args vs. non-default args."""
+    args, vararg, varkwarg, defvals = inspect.getargspec(command)
+
+    assert varkwarg is None, 'Variable kwargs are not allowed in commands.'
+
+    if args is None:
+        args = tuple()
+    if defvals is None:
+        defvals = tuple()
+
+    # Avoid the self argument.
+    if isinstance(command, types.MethodType):
+        args = args[1:]
+
+    nargs = len(args) - len(defvals)
+    args = list(zip(args[:nargs], [intern('default')]*nargs)) + list(zip(args[nargs:], defvals))
+
+    return args, vararg
 
 class System(object):
     """System namespace for the clr tool.

--- a/clr/commands.py
+++ b/clr/commands.py
@@ -2,7 +2,6 @@ from __future__ import print_function
 from importlib import import_module
 from builtins import zip
 from builtins import object
-from past.builtins import intern
 from dataclasses import dataclass
 import inspect
 import sys

--- a/clr/commands.py
+++ b/clr/commands.py
@@ -13,7 +13,8 @@ import difflib
 import clr.config
 
 NAMESPACE_KEYS = clr.config.commands().keys() | {'system'}
-# Load lazily.
+# Load lazily namespace modules as needed. Some have expensive/occasionally
+# failing initialization.
 __namespaces = {}
 
 def get_command_spec(command):

--- a/clr/commands.py
+++ b/clr/commands.py
@@ -11,6 +11,9 @@ import difflib
 
 import clr.config
 
+# Sentinal for args get in get_command_spec to indicate there is no default.
+NO_DEFAULT = object()
+
 NAMESPACE_KEYS = clr.config.commands().keys() | {'system'}
 # Load lazily namespace modules as needed. Some have expensive/occasionally
 # failing initialization.
@@ -96,7 +99,7 @@ def get_command_spec(cmd):
         args = args[1:]
 
     nargs = len(args) - len(defvals)
-    args = list(zip(args[:nargs], [intern('default')]*nargs)) + list(zip(args[nargs:], defvals))
+    args = list(zip(args[:nargs], [NO_DEFAULT]*nargs)) + list(zip(args[nargs:], defvals))
 
     return args, vararg
 
@@ -145,7 +148,7 @@ class System(object):
         spec, vararg = get_command_spec(command)
 
         def is_default(spec):
-            return a_s[1] == 'default'
+            return spec[1] is NO_DEFAULT
         req = [spec_item for spec_item in spec if is_default(spec_item)]
         notreq = [spec_item for spec_item in spec if not is_default(spec_item)]
 

--- a/clr/commands.py
+++ b/clr/commands.py
@@ -22,9 +22,6 @@ def get_namespaces():
     for key in NAMESPACE_KEYS: get_namespace(key)
     return __namespaces
 
-def has_namespace(key):
-    return key in NAMESPACE_KEYS
-
 def load_namespace(key):
     if key == 'system':
         return System()
@@ -70,7 +67,7 @@ def resolve_command(query):
             namespace_key = query
             command_name = ''
 
-    if not has_namespace(namespace_key):
+    if namespace_key not in NAMESPACE_KEYS:
         close_matches = _get_close_matches(namespace_key, NAMESPACE_KEYS)
         print(f"Error! Command namespace '{namespace_key}' does not exist.\nClosest matches: {close_matches}\n\nAvaliable namespaces: {sorted(NAMESPACE_KEYS)}", file=sys.stderr)
         sys.exit(1)

--- a/clr/commands.py
+++ b/clr/commands.py
@@ -3,7 +3,6 @@ from importlib import import_module
 from builtins import zip
 from builtins import object
 from past.builtins import intern
-from typing import NamedTuple
 from dataclasses import dataclass
 import inspect
 import sys

--- a/clr/main.py
+++ b/clr/main.py
@@ -1,14 +1,13 @@
 from __future__ import absolute_import
 from __future__ import print_function
 
-from past.builtins import intern
 from builtins import range
 import optparse
 import sys
 import types
 
 import clr
-from clr.commands import get_command_spec, resolve_command
+from clr.commands import get_command_spec, resolve_command, NO_DEFAULT
 from clr.options import add_global_options, handle_global_options
 from functools import reduce
 
@@ -47,7 +46,7 @@ def main():
 
         o = optparse.Option('--%s' % a)
 
-        if defval is intern('default'):
+        if defval is NO_DEFAULT:
             pass
         elif isinstance(defval, bool):
             if defval:
@@ -64,7 +63,7 @@ def main():
 
             o.type = t[0]
 
-        if defval is not intern('default'):
+        if defval is not NO_DEFAULT:
             o.default = defval
 
         o.dest = '_cmd_%s' % a
@@ -84,7 +83,7 @@ def main():
         del kwargs[spec[i][0]]
 
     # Now make sure that all nondefault arguments are specified.
-    defargs = [a_s for a_s in spec if a_s[1] is intern('default')]
+    defargs = [a_s for a_s in spec if a_s[1] is NO_DEFAULT]
     if len(args) < len(defargs):
         print('Not all non-default arguments were specified!', file=sys.stderr)
         sys.exit(1)

--- a/clr/main.py
+++ b/clr/main.py
@@ -24,11 +24,11 @@ def main():
     # Find the first arg that does not start with a '-'. This is the
     # command.
     try:
-        cmd_ = argv[1]
+        query = argv[1]
     except IndexError:
-        cmd_ = 'system:help'
+        query = 'system:help'
 
-    _, cmd, ns_, cmd_ = resolve_command(cmd_)
+    _, cmd, namespace_key, cmd_name = resolve_command(query)
 
     # Parse the command line arguments.
     spec, vararg = get_command_spec(cmd)
@@ -90,7 +90,7 @@ def main():
         sys.exit(1)
 
     # Special case: print global option help.
-    if ns_ == 'system' and cmd_ == 'help':
+    if namespace_key == 'system' and cmd_name == 'help':
         print(ghelp)
 
     # Compose the run hooks.


### PR DESCRIPTION
- Misc cleanup
  - Little bit of restructuring
  - Standardize on terminology

- Suggests close matches when namespace or command aren't found

- More robust to failures during help.

- Will have to follow up merge with a new release and update to color/color:build/python-packages/editable/clr

- Next up: caching and auto completion

```
$ clr pipelines
Error! Command namespace 'pipelines' does not exist.
Closest matches: ['pipeline', 'pipeline_ops', 'counseling']

Available namespaces: ['ancestry', 'audit', 'census', 'clinical_support', 'clinvar', 'confirmation', 'content', 'counseling', 'covid', 'cypress', 'data', 'data_return', 'datasets', 'deploy', 'django', 'ec2', 'elasticsearch', 'etl', 'js', 'keyfile', 'lambda', 'load_test', 'perf', 'pg', 'pipeline', 'pipeline_ops', 'product', 'reports', 's3', 'src', 'support', 'swagger', 'system', 'test_fixtures', 'usd', 'validation', 'variants', 'vcf', 'web', 'wisdom']
```

```
$ clr pipeline:val
Error! Command 'val does not exist in namespace 'pipeline'.
Closest matches: ['validate_batch']

Available commands: ['array_integration_test', 'async_run_job', 'call_aldy_bam', 'call_aldy_sample', 'call_diplotype_vcf', 'call_variants', 'call_variants_toil', 'clean_toil_s3_jobstore', 'compare_batches', 'compare_lcwgs_imputed_vcf_with_array', 'compute_insertion_features', 'compute_split_reads', 'destroy_toil_cluster', 'generate_probe_performance_report', 'graph', 'help', 'igv_link', 'import_batch_cnv_candidates', 'integration_test', 'job_status', 'kill_toil_pipeline', 'launch_toil_cluster', 'mark_batch_as_abandoned', 'plot_coverage', 'prod_batch_integration_test', 'prod_batch_lcwgs_integration_test', 'run_custom_job_toil', 'run_job', 'run_toil_cwl_workflow', 'validate_batch', 'wgs_integration_test']
```

```
$ clr pipeline:valdate_batch
Error! Command 'valdate_batch does not exist in namespace 'pipeline'.
Closest matches: ['validate_batch', 'compare_batches', 'call_aldy_bam']
```

```
$ clr help pipeline

pipeline - variant calling pipeline commands
  array_integration_test [args...]
    Runs...
```

```
$ clr help pipelined

Error! Command namespace 'pipelined' does not exist.
Closest matches: ['pipeline', 'pipeline_ops', 'counseling']
```

```
$ clr help v

Error! Command namespace 'v' does not exist.
Closest matches: ['vcf', 'validation', 'variants']
```

From my laptop:
```
$ clr help | grep product -C 3
[2021-04-28T03:24:01Z ddtrace.monkey] INFO: patched 1/1 modules (celery)
[2021-04-28T03:24:05Z botocore.credentials] INFO: Found credentials in environment variables.
  datasets             - datasets commands
  data_return          - Utility commands to export genetic data for clients.
  pg                   - PostgreSQL commands
  product              - ERROR Could not load. See `clr help product`
  reports              - Utility functions for dealing with reports related tasks
  lambda               - AWS Lambda commands
  vcf                  - vcf commands
```

```
$ clr help product

[2021-04-28T03:24:37Z ddtrace.monkey] INFO: patched 1/1 modules (celery)
product - Error importing module 'clr_commands.product' for namespace 'product':

could not connect to server: Connection refused
	Is the server running on host "localhost" (::1) and accepting
	TCP/IP connections on port 5432?
could not connect to server: Connection refused
	Is the server running on host "localhost" (127.0.0.1) and accepting
	TCP/IP connections on port 5432?
```

```
$ clr product:aaa
[2021-04-28T03:34:41Z ddtrace.monkey] INFO: patched 1/1 modules (celery)
Error! Command 'aaa' does not exist in namespace 'product' - ERROR Could not load. See `clr help product`.
Closest matches: []

Available commands: []
```