### PR TITLE
Fix deps in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,8 @@
 from setuptools import setup
 
+requirements = [
+  "dataclasses==0.8;python_version<'3.7'"
+]
 setup(name = "clr",
       version = "0.2.0",
       description = "A command line tool for executing custom python scripts.",
@@ -10,11 +13,9 @@ setup(name = "clr",
       entry_points = {
         "console_scripts": [ "clr = clr:main" ],
       },
-      install_requires=[
-        "dataclasses"
-      ],
+      install_requires=requirements,
       setup_requires=['pytest-runner'],
-      tests_require=['pytest'],
+      tests_require=requirements + ['pytest==6.2.4'],
       license = "MIT",
       include_package_data=True,
       package_data={


### PR DESCRIPTION
```
$ python3.6 -m venv venv
$ cd clr
$ python --version
Python 2.7.16
$ source ../venv/bin/activate
(venv) $ python --version
Python 3.6.13
(venv) $ python setup.py test
running pytest
Searching for pytest
Best match: pytest 6.2.4
Processing pytest-6.2.4-py3.6.egg

Using /Users/michael.cusack/dev/clr/.eggs/pytest-6.2.4-py3.6.egg
Searching for dataclasses==0.8; python_version < "3.7"
Best match: dataclasses 0.8
Processing dataclasses-0.8-py3.6.egg

....various installing...

======================================================================================== 2 passed in 0.05s =========================================================================================
```