### PR TITLE
Allow boolean return values for clr commands to be reflected as return codes.

### DIFF
--- a/clr/main.py
+++ b/clr/main.py
@@ -19,6 +19,7 @@ def main(argv=None):
     result = namespace.command_callables[cmd_name](
         *bound_args.args, **bound_args.kwargs
     )
-    # Support exit codes. This will support int and bool return values.
-    if isinstance(result, int):
+    # Support exit codes. This supports int and bool return values.
+    if isinstance(result, (int, bool)):
+        # print(f"Result: {result}", file=sys.stderr)
         sys.exit(result)

--- a/clr/main.py
+++ b/clr/main.py
@@ -19,6 +19,6 @@ def main(argv=None):
     result = namespace.command_callables[cmd_name](
         *bound_args.args, **bound_args.kwargs
     )
-    # Support exit codes.
-    if type(result) == int:
+    # Support exit codes. This will support int and bool return values.
+    if isinstance(result, int):
         sys.exit(result)

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ requirements = ["dataclasses;python_version<'3.7'"]
 
 setup(
     name="clr",
-    version="0.3.14",
+    version="0.3.15",
     description="A command line tool for executing custom python scripts.",
     author="Color",
     author_email="dev@getcolor.com",


### PR DESCRIPTION
```
mpcusack@mpcp15:~/dev/clr$ python
Python 3.9.7 (default, Sep  9 2021, 23:20:13) 
[GCC 9.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> isinstance(True, int)
True
>>> isinstance(False, int)
True
>>> isinstance(999, int)
True
>>> 
mpcusack@mpcp15:~/dev/clr$ python -c "import sys; sys.exit(True)" ; echo $?
1
mpcusack@mpcp15:~/dev/clr$ python -c "import sys; sys.exit(False)" ; echo $?
0
mpcusack@mpcp15:~/dev/clr$ python -c "import sys; sys.exit(999)" ; echo $?
231
mpcusack@mpcp15:~/dev/clr$ python -c "import sys; sys.exit(222)" ; echo $?
222
```