### PR TITLE
check to see if handler is callable

### DIFF
--- a/clr/main.py
+++ b/clr/main.py
@@ -10,12 +10,15 @@ from clr.commands import resolve_command, get_namespace
 
 DEBUG_MODE = os.environ.get("CLR_DEBUG", "").lower() in ("true", "1")
 
+
 def on_exit(signum, frame):
     beeline.add_trace_field("killed_by_signal", signal.Signals(signum).name)
     beeline.close()
 
+
 signal.signal(signal.SIGINT, on_exit)
 signal.signal(signal.SIGTERM, on_exit)
+
 
 @contextmanager
 def init_beeline(namespace_key, cmd_name):
@@ -81,6 +84,8 @@ def main(argv=None):
                 )
                 if isinstance(result, (int, bool)):
                     exit_code = int(result)
+            except SystemExit as err:
+                exit_code = err.code
             except:
                 print(traceback.format_exc(), file=sys.stderr)
                 beeline.add_trace_field("raised_exception", True)

--- a/clr/main.py
+++ b/clr/main.py
@@ -16,8 +16,19 @@ def on_exit(signum, frame):
     beeline.close()
 
 
-signal.signal(signal.SIGINT, on_exit)
-signal.signal(signal.SIGTERM, on_exit)
+def wrap_signal_handler(sig):
+    old_handler = signal.getsignal(sig)
+
+    def new_handler(signum, frame):
+        on_exit(signum, frame)
+        old_handler(signum, frame)
+
+    signal.signal(sig, new_handler)
+
+
+wrap_signal_handler(signal.SIGINT)
+wrap_signal_handler(signal.SIGTERM)
+
 
 
 @contextmanager

--- a/clr/main.py
+++ b/clr/main.py
@@ -23,6 +23,10 @@ def wrap_signal_handler(sig):
         on_exit(signum, frame)
         if callable(old_handler):
             old_handler(signum, frame)
+        elif old_handler == signal.SIG_DFL:
+            # reset old signal handler to default handler
+            signal.signal(signal.SIGTERM, old_handler)
+            os.kill(os.getpid(), signum)  # retrigger signal to get default behavior
 
     signal.signal(sig, new_handler)
 

--- a/clr/main.py
+++ b/clr/main.py
@@ -21,14 +21,14 @@ def wrap_signal_handler(sig):
 
     def new_handler(signum, frame):
         on_exit(signum, frame)
-        old_handler(signum, frame)
+        if callable(old_handler):
+            old_handler(signum, frame)
 
     signal.signal(sig, new_handler)
 
 
 wrap_signal_handler(signal.SIGINT)
 wrap_signal_handler(signal.SIGTERM)
-
 
 
 @contextmanager

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ requirements = ["dataclasses;python_version<'3.7'", "honeycomb-beeline"]
 
 setup(
     name="clr",
-    version="0.3.15",
+    version="0.3.16",
     description="A command line tool for executing custom python scripts.",
     author="Color",
     author_email="dev@getcolor.com",


### PR DESCRIPTION
@mpcusack-color pointed out that signal handlers might not be callable.

This pr fixes the signal handler wrapper by checking to see if the old_handler was callable.
If the old handler is SIGDFL (which is the default handler) we reset the handler to SIGDFL and send the signal again by using os.kill

### Testing plan

1. run a program with no signal handlers set for SIGTERM, verified that `kill pid` was broken before this fix
2. above but program was properly killed.